### PR TITLE
Fix dotenv parsing to ignore literal hash characters

### DIFF
--- a/scripts/run.ps1
+++ b/scripts/run.ps1
@@ -50,16 +50,25 @@ function Import-DotEnv {
         }
 
         $name = $match.Groups['key'].Value
-        $value = $match.Groups['value'].Value.Trim()
+        $value = $match.Groups['value'].Value
+        $trimmedValue = $value.Trim()
 
-        if ($value.StartsWith('"') -and $value.EndsWith('"')) {
-            $value = $value.Substring(1, $value.Length - 2).Replace('\\"', '"')
-        } elseif ($value.StartsWith("'") -and $value.EndsWith("'")) {
-            $value = $value.Substring(1, $value.Length - 2)
+        if ($trimmedValue.StartsWith('"') -and $trimmedValue.EndsWith('"')) {
+            $value = $trimmedValue.Substring(1, $trimmedValue.Length - 2).Replace('\\"', '"')
+        } elseif ($trimmedValue.StartsWith("'") -and $trimmedValue.EndsWith("'")) {
+            $value = $trimmedValue.Substring(1, $trimmedValue.Length - 2)
         } else {
-            $hashIndex = $value.IndexOf('#')
-            if ($hashIndex -ge 0) {
-                $value = $value.Substring(0, $hashIndex)
+            $commentIndex = -1
+            for ($i = 0; $i -lt $value.Length; $i++) {
+                if ($value[$i] -eq '#') {
+                    if ($i -gt 0 -and [char]::IsWhiteSpace($value[$i - 1])) {
+                        $commentIndex = $i
+                        break
+                    }
+                }
+            }
+            if ($commentIndex -ge 0) {
+                $value = $value.Substring(0, $commentIndex)
             }
             $value = $value.Trim()
         }

--- a/scripts/seed-demo.ps1
+++ b/scripts/seed-demo.ps1
@@ -41,16 +41,25 @@ function Import-DotEnv {
         }
 
         $name = $match.Groups['key'].Value
-        $value = $match.Groups['value'].Value.Trim()
+        $value = $match.Groups['value'].Value
+        $trimmedValue = $value.Trim()
 
-        if ($value.StartsWith('"') -and $value.EndsWith('"')) {
-            $value = $value.Substring(1, $value.Length - 2).Replace('\\"', '"')
-        } elseif ($value.StartsWith("'") -and $value.EndsWith("'")) {
-            $value = $value.Substring(1, $value.Length - 2)
+        if ($trimmedValue.StartsWith('"') -and $trimmedValue.EndsWith('"')) {
+            $value = $trimmedValue.Substring(1, $trimmedValue.Length - 2).Replace('\\"', '"')
+        } elseif ($trimmedValue.StartsWith("'") -and $trimmedValue.EndsWith("'")) {
+            $value = $trimmedValue.Substring(1, $trimmedValue.Length - 2)
         } else {
-            $hashIndex = $value.IndexOf('#')
-            if ($hashIndex -ge 0) {
-                $value = $value.Substring(0, $hashIndex)
+            $commentIndex = -1
+            for ($i = 0; $i -lt $value.Length; $i++) {
+                if ($value[$i] -eq '#') {
+                    if ($i -gt 0 -and [char]::IsWhiteSpace($value[$i - 1])) {
+                        $commentIndex = $i
+                        break
+                    }
+                }
+            }
+            if ($commentIndex -ge 0) {
+                $value = $value.Substring(0, $commentIndex)
             }
             $value = $value.Trim()
         }


### PR DESCRIPTION
## Summary
- update the PowerShell .env loaders to keep literal # characters in unquoted values unless the hash begins an inline comment

## Testing
- pytest -q *(fails: missing dependencies such as fastapi, dotenv, sqlalchemy)*

------
https://chatgpt.com/codex/tasks/task_e_68e2265ad398832db2c3a50aae9c820f